### PR TITLE
Updated Readme file to help users to Enable "Less Secure Apps" to run the Script error free.

### DIFF
--- a/scripts/Email-Sender/readme.md
+++ b/scripts/Email-Sender/readme.md
@@ -25,3 +25,18 @@ A Python3 script to automate the email sending process
   ```bash
   python system-usage.py
   ```
+Note: Make sure you have enabled the "Less Secure Apps" from Google account security
+to send emails using that script.
+
+### Steps to Allow Less Secure Apps
+
+ * Visit: https://myaccount.google.com/intro/security
+ * Disable 2-Step Verification if enabled (See the image below).
+ ![Screenshot (504)](https://user-images.githubusercontent.com/73809690/135844785-6bb4aaf1-b647-4d79-aa1d-742117a8547e.png)
+ 
+ * Then Turn On Less Secure Apps (See the image below)
+ ![Screenshot (505)](https://user-images.githubusercontent.com/73809690/135844893-43e10b99-2a84-4637-af4b-192afb8c1e4d.png)
+ 
+ * Now you are good to go.
+
+

--- a/scripts/Email-Sender/script.py
+++ b/scripts/Email-Sender/script.py
@@ -1,4 +1,5 @@
 # Script to automate Email Sending
+"""Note: To run this script enable "Less Secure Apps" shown in Readme file"""
 import smtplib
 
 to = input("Enter the Email of recipent:\n")


### PR DESCRIPTION
# Description

When a new user try to send emails using the Email sender scripts it throws an error because some users enabled the 2-Step Verification in their gmail id or "Less secure app" is not enabled in their email id security section. So i have updated the readme file how can you enable it to use the email sender script wisely and efficiently. 


## Type of change


- Added some guide to use the script wisely 
  and efficiently. 

## Has This Been Tested?

- [x] I confirm that I have tested my script locally and verified that it works as intended.


## Checklist:

- [x] I have gone through the contributing guidelines before making this Pull Request.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
